### PR TITLE
Fix conflict happening between Java's assumed Integer vs intended Long type

### DIFF
--- a/src/main/java/com/brianeno/statemachine/SpringStateMachineApplication.java
+++ b/src/main/java/com/brianeno/statemachine/SpringStateMachineApplication.java
@@ -28,15 +28,15 @@ public class SpringStateMachineApplication implements CommandLineRunner {
 
         // since version 3.x need to send events reactively
         stateMachine.sendEvent(Mono.just(MessageBuilder.withPayload(ArticleEvents.EDIT_ARTICLE)
-            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1)
+            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1L)
             .build())).doOnComplete(() -> System.out.println("Initial Edit Article handling complete")).subscribe();
 
         stateMachine.sendEvent(Mono.just(MessageBuilder.withPayload(ArticleEvents.REVIEW_ARTICLE)
-            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1)
+            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1L)
             .build())).doOnComplete(() -> System.out.println("Review Article handling complete")).subscribe();
 
         stateMachine.sendEvent(Mono.just(MessageBuilder.withPayload(ArticleEvents.PUBLISH_ARTICLE)
-            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1)
+            .setHeader(ArticleServiceImpl.ARTICLE_ID_HEADER, 1L)
             .build())).doOnComplete(() -> System.out.println("Publish Article handling complete")).subscribe();
    */
     }


### PR DESCRIPTION
Tried to fire up what you had Brian and it failed in a hard-to-diagnose way. Eventually after adding an errorAction for debugging like
```java
    @Bean
    public Action<ArticleStates, ArticleEvents> errorAction() {
        return context -> {
            // RuntimeException("MyError") added to context
            Exception exception = context.getException();
            System.out.println(exception.getMessage());
        };
    }
```
I found that it was an error at the first line of each Action because your casting of Object to Long when the Object type was Integer was breaking the state machine.